### PR TITLE
Set env variable before build

### DIFF
--- a/convox_deploy_v2.sh
+++ b/convox_deploy_v2.sh
@@ -160,13 +160,17 @@ echo_with_feedback() {
 }
 
 set_revision_env() {
-   convox env set REVISION=$GIT_HASH --app $APP_NAME --rack $RACK_NAME --promote
+   convox env set REVISION=$GIT_HASH --app $APP_NAME --rack $RACK_NAME
 }
 
 main() {
     check_arg_requirements
 
     replace_tag_with_git_hash
+
+    echo_with_feedback \
+        set_revision_env \
+        "Setting REVISION=$GIT_HASH"
 
     echo_with_feedback \
         run_before_build_script \
@@ -205,10 +209,6 @@ main() {
     echo_with_feedback \
         promote_release \
         "Promoting $RELEASE_ID to $CONVOX_HOST..."
-
-    echo_with_feedback \
-        set_revision_env \
-        "Setting REVISION=$GIT_HASH"
 
     echo "${BOLD}✅  Deployment complete!${NORMAL}"
 }

--- a/convox_deploy_v2.sh
+++ b/convox_deploy_v2.sh
@@ -159,15 +159,9 @@ echo_with_feedback() {
     fi
 }
 
-# Sets an env variable in the convox build so it's easy to identify what build is running
-# Can be used by in-app health checks
-#set_revision_env() {
-  # This is currently disabled because it creates a release based on the current running release,
-  # whereas we want to set this on the new release prior to releasing it
-  # see: https://github.com/convox/rack/issues/962
-
-  # convox env set REVISION=$GIT_HASH --app $APP_NAME --rack $RACK_NAME
-#}
+set_revision_env() {
+   convox env set REVISION=$GIT_HASH --app $APP_NAME --rack $RACK_NAME --promote
+}
 
 main() {
     check_arg_requirements
@@ -200,12 +194,6 @@ main() {
         build_convox_release \
         "Building $APP_NAME release..."
 
-    # This is disabled due to a bug - see set_revision_env() for more inof
-    #
-    # echo_with_feedback \
-    #     set_revision_env \
-    #     "Setting REVISION=$GIT_HASH"
-
     echo_with_feedback \
         get_latest_release_id \
         "Grabbing last release from API..."
@@ -217,6 +205,10 @@ main() {
     echo_with_feedback \
         promote_release \
         "Promoting $RELEASE_ID to $CONVOX_HOST..."
+
+    echo_with_feedback \
+        set_revision_env \
+        "Setting REVISION=$GIT_HASH"
 
     echo "${BOLD}✅  Deployment complete!${NORMAL}"
 }


### PR DESCRIPTION
The only way to update the env with the `$REVISION` env variable is to set the env post-promotion of the new release. Convox may fix this soon (see https://github.com/convox/rack/issues/962) but in the meantime this is the only sure-fire way to do it.